### PR TITLE
Added option to reset application in settings

### DIFF
--- a/lib/features/counter/provider/counter_list_provider.dart
+++ b/lib/features/counter/provider/counter_list_provider.dart
@@ -22,6 +22,12 @@ class CounterListProvider with ChangeNotifier {
     await repository.saveCounters(_counters);
   }
 
+  Future<void> clearCounters() async {
+    _counters = [];
+    saveCounters();
+    notifyListeners();
+  }
+
   void addCounter(CounterModel newCounter) {
     _counters.add(newCounter);
     saveCounters();

--- a/lib/features/settings/settings_page.dart
+++ b/lib/features/settings/settings_page.dart
@@ -1,5 +1,3 @@
-// settings_page.dart
-
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -113,9 +111,46 @@ class SettingsPage extends StatelessWidget {
                     timerListProvider.importTimersFromData);
               },
             ),
+            const Divider(),
+            ListTile(
+              title: const Text('Reset Application Data'),
+              trailing: const Icon(Icons.lock_reset),
+              onTap: () => showResetDialog(
+                  context, counterListProvider, timerListProvider),
+            ),
           ],
         ),
       ),
+    );
+  }
+
+  showResetDialog(BuildContext context, CounterListProvider counterProvider,
+      TimerListProvider timerProvider) {
+    showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Reset Application Data'),
+          content:
+              const Text('Are you sure to clear all the application data?'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                counterProvider.clearCounters();
+                timerProvider.clearTimers();
+                Navigator.of(context).pop();
+              },
+              child: const Text('Yes'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('No'),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/features/timer/provider/timer_list_provider.dart
+++ b/lib/features/timer/provider/timer_list_provider.dart
@@ -25,6 +25,12 @@ class TimerListProvider with ChangeNotifier {
     await repository.saveTimers(_timers);
   }
 
+  Future<void> clearTimers() async {
+    _timers = [];
+    saveTimers();
+    notifyListeners();
+  }
+
   TimerModel getTimer(TimerModel newTimer) {
     return _timers.firstWhere((timer) => timer.id == newTimer.id);
   }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->
Added button in settings page to reset application wide data on counters and timers without going through manually deleting each counter and timer.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
